### PR TITLE
chore: add default tags to `aws` provider

### DIFF
--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -10,6 +10,12 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 provider "aws" {
+  # tags for all resources
+  default_tags {
+    tags = {
+      ManagedBy        = "terraform"
+    }
+  }
   region = "us-east-1"
   allowed_account_ids = ["651111921281"]
 }


### PR DESCRIPTION
default_tags provides a way to add tags to all resources managed by terraform.