### PR TITLE
chore: remove hardcoded cloudfront cache policy

### DIFF
--- a/terraform/website/dependencies.tf
+++ b/terraform/website/dependencies.tf
@@ -3,3 +3,8 @@
 data "aws_route53_zone" "main" {
   name = var.domain
 }
+
+# reference an AWS managed cloudfront cache policy
+data "aws_cloudfront_cache_policy" "cache-optimized" {
+  name = "Managed-CachingOptimized"
+}

--- a/terraform/website/main.tf
+++ b/terraform/website/main.tf
@@ -76,7 +76,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   default_cache_behavior {
-    cache_policy_id        = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    cache_policy_id        = data.aws_cloudfront_cache_policy.cache-optimized.id
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
     allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]


### PR DESCRIPTION
uses an AWS managed cache policy that is looked up by name instead of a hard coded GUID

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html