### PR TITLE
fix: darken/lighten color variables

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -93,7 +93,7 @@ a {
     text-decoration: none;
 
     &:visited {
-        color: darken($brand-color, 15%);
+        color: color.scale($brand-color, $lightness: -25%);
     }
 
     &:hover {

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,6 +3,7 @@
 sitemap_exclude: y
 ---
 @charset "utf-8";
+@use 'sass:color';
 
 
 
@@ -19,8 +20,8 @@ $background-color: #fdfdfd;
 $brand-color:      #2a7ae2;
 
 $grey-color:       #828282;
-$grey-color-light: lighten($grey-color, 40%);
-$grey-color-dark:  darken($grey-color, 25%);
+$grey-color-light: color.scale($grey-color, $lightness: 40%);
+$grey-color-dark:  color.scale($grey-color, $lightness: -25%);
 
 // Width of the content area
 $content-width:    800px;


### PR DESCRIPTION
They were using a deprecated function that was causing a warning in the console