### PR TITLE
feat(download): update English downloads to v5.5.10 and fix Arabic ti…

### DIFF
--- a/download.html
+++ b/download.html
@@ -27,11 +27,16 @@ As an alternative, you can download the stand alone version, which will need to 
 
 <ul id="download">
 
-    <li class="colorcop"><h3>English v5.4.3</h3>
+    <li class="colorcop"><h3>English v5.5.10</h3>
         <ul>
             <li class="dtype"><h4>self-installing</h4>
                 <ul>
-                    <li class="typval"><a class="lnk" title="download color cop" href="/tools/colorcop/colorcop-setup.exe">colorcop-setup.exe</a></li>
+                    <li class="typval">
+                        <a class="lnk" title="download color cop"
+                           href="https://github.com/ColorCop/ColorCop/releases/download/v5.5.10/colorcop-setup.exe">
+                           colorcop-setup.exe
+                        </a>
+                    </li>
                     <li class="typval">The self installing version.  Simply click, run, and use.
 <br /><br /><br /></li>
                 </ul>
@@ -39,11 +44,16 @@ As an alternative, you can download the stand alone version, which will need to 
         </ul>
 
     </li>
-    <li class="colorcop"><h3>English v5.4.5</h3>
+    <li class="colorcop"><h3>English v5.5.10</h3>
         <ul>
             <li class="dtype"><h4>stand alone</h4>
                 <ul>
-                    <li class="typval"><a class="lnk" title="download color cop" href="/tools/colorcop/colorcop.zip">colorcop.zip</a></li>
+                    <li class="typval">
+                        <a class="lnk" title="download color cop"
+                           href="https://github.com/ColorCop/ColorCop/releases/download/v5.5.10/colorcop.zip">
+                           colorcop.zip
+                        </a>
+                    </li>
                     <li class="typval">The latest version of Color Cop.  See readme.txt for a list of changes.</li>
                 </ul>
             </li>
@@ -152,7 +162,7 @@ As an alternative, you can download the stand alone version, which will need to 
         <ul>
             <li class="dtype"><h4>stand alone</h4>
                 <ul>
-                    <li class="typval"><a class="lnk" title="download color cop vietnamese" href="/tools/colorcop/Color-Cop-v5.4.5-Arabic.rar">Color-Cop-v5.4.5-Arabic.rar</a></li>
+                    <li class="typval"><a class="lnk" title="download color cop arabic" href="/tools/colorcop/Color-Cop-v5.4.5-Arabic.rar">Color-Cop-v5.4.5-Arabic.rar</a></li>
                     <li class="typval">Arabic translation done by Abo Rehaam</li>
                 </ul>
             </li>


### PR DESCRIPTION
…tle attribute

- bump English version headings from 5.4.3 / 5.4.5 → 5.5.10
- replace local installer + ZIP links with GitHub Release asset URLs
- reformat `<li>` blocks for cleaner multi‑line structure
- correct Arabic download link title (“vietnamese” → “arabic”)