### PR TITLE
refactor(ci): move terragrunt output parsing into reusable script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ on:
       branch:
         description: Branch to deploy
         required: true
-        # user must select a branch when triggering workflow manually
 
 env:
   working_dir: terragrunt
@@ -29,8 +28,6 @@ jobs:
     - name: Checkout selected branch
       uses: actions/checkout@v6
       with:
-        # If workflow_dispatch, use the selected branch.
-        # If push event, use the branch that triggered the workflow.
         ref: ${{ github.event.inputs.branch || github.ref_name }}
 
     - name: Configure AWS Credentials
@@ -41,10 +38,6 @@ jobs:
         aws-region: us-east-1
 
     - name: Initialize Terragrunt (backend + providers)
-      # terragrunt init:
-      # - Configures the remote backend (S3 + DynamoDB)
-      # - Downloads provider versions pinned in the lockfile
-      # - Prepares the working directory for plan/apply
       uses: gruntwork-io/terragrunt-action@v3
       env:
         TERRAGRUNT_DISABLE_COPY: true
@@ -60,7 +53,6 @@ jobs:
         tg_dir: ${{ env.working_dir }}
         tg_command: "run-all plan"
 
-
     - name: Terragrunt Apply
       uses: gruntwork-io/terragrunt-action@v3
       env:
@@ -69,12 +61,11 @@ jobs:
         tg_dir: ${{ env.working_dir }}
         tg_command: "run-all apply"
 
+    # TODO(j4y): Replace hard-coded path once multiple stacks exist.
     - name: Read Values
       id: terragrunt_output
       run: |
-        cd terragrunt/live/website
-        printf "distribution_id=%s\n" $(terragrunt output distribution_id) >> "$GITHUB_OUTPUT"
-        printf "bucket_name=%s\n" $(terragrunt output bucket_name) >> "$GITHUB_OUTPUT"
+        ./scripts/read_terragrunt_outputs.sh terragrunt/live/website
 
     - name: Build Jekyll project
       run: |
@@ -93,4 +84,3 @@ jobs:
 
     - name: Invalidate Cloudfront
       run: aws cloudfront create-invalidation --distribution-id ${{ steps.terragrunt_output.outputs.distribution_id }} --paths "/*"
-

--- a/scripts/read_terragrunt_outputs.sh
+++ b/scripts/read_terragrunt_outputs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   read_terragrunt_outputs.sh <terragrunt_module_path>
+#
+# Example:
+#   read_terragrunt_outputs.sh terragrunt/live/website
+#
+# Outputs:
+#   Writes distribution_id and bucket_name to $GITHUB_OUTPUT
+
+MODULE_PATH="${1:-}"
+
+if [[ -z "$MODULE_PATH" ]]; then
+  echo "ERROR: Missing module path argument" >&2
+  exit 1
+fi
+
+cd "$MODULE_PATH"
+
+# Extract JSON outputs
+OUT_JSON=$(terragrunt output --json)
+
+# Parse values safely
+DISTRIBUTION_ID=$(echo "$OUT_JSON" | jq -r '.distribution_id.value // empty')
+BUCKET_NAME=$(echo "$OUT_JSON" | jq -r '.bucket_name.value // empty')
+
+# Validate
+if [[ -z "$DISTRIBUTION_ID" ]]; then
+  echo "ERROR: distribution_id output is missing or empty" >&2
+  exit 1
+fi
+
+if [[ -z "$BUCKET_NAME" ]]; then
+  echo "ERROR: bucket_name output is missing or empty" >&2
+  exit 1
+fi
+
+# Export to GitHub Actions if available
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "distribution_id=$DISTRIBUTION_ID" >> "$GITHUB_OUTPUT"
+  echo "bucket_name=$BUCKET_NAME" >> "$GITHUB_OUTPUT"
+else
+  echo "GITHUB_OUTPUT not set; printing values for local use"
+  echo "distribution_id=$DISTRIBUTION_ID"
+  echo "bucket_name=$BUCKET_NAME"
+fi


### PR DESCRIPTION
Replaces inline fragile terragrunt output extraction in deploy workflow with a dedicated script (scripts/read_terragrunt_outputs.sh). This improves safety, adds validation, supports local execution, and reduces workflow complexity. Also removes outdated comments and adds a TODO for future multi-stack support.